### PR TITLE
Small changes for release

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ FROM openjdk:17-jdk-alpine
 
 ENV LAS2PEER_PORT=9011
 
-RUN apk add --update bash mysql-client curl dos2unix && rm -f /var/cache/apk/*
+RUN apk add --update bash mysql-client curl && rm -f /var/cache/apk/*
 RUN addgroup -g 1000 -S las2peer && \
     adduser -u 1000 -S las2peer -G las2peer
 
@@ -11,12 +11,6 @@ WORKDIR /src
 
 # run the rest as unprivileged user
 USER las2peer
-RUN dos2unix gradlew
-RUN dos2unix gradle.properties
-RUN dos2unix /src/docker-entrypoint.sh
-RUN dos2unix /src/etc/i5.las2peer.webConnector.WebConnector.properties
-RUN dos2unix /src/etc/i5.las2peer.services.moodleDataProxyService.MoodleDataProxyService.properties
-RUN dos2unix /src/etc/i5.las2peer.registry.data.RegistryConfiguration.properties
 RUN chmod +x gradlew && ./gradlew build --exclude-task test
 
 EXPOSE $LAS2PEER_PORT

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
-core.version=1.2.2
+core.version=1.2.3
 service.name=i5.las2peer.services.moodleDataProxyService
 service.class=MoodleDataProxyService
 service.version=1.5.0


### PR DESCRIPTION
- Changed las2peer version to 1.2.3 to remove OIDC error caused by wrong URL in Webconnector of 1.2.2
- Removed dos2unix commands in Dockerfile, used in local development